### PR TITLE
Like action

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Other kinds of relationships will result in ```Cannot create relationship``` err
 returns    
 ```
 {
+  "likes": 0,
   "product_id": 1,
   "recommendation_product_id": 2,
   "relationship": "UP_SELL"
@@ -99,6 +100,7 @@ body
 returns    
 ```
 {
+  "likes": 0,
   "product_id": 1,
   "recommendation_product_id": 2,
   "relationship": "CROSS_SELL"
@@ -116,13 +118,14 @@ body
   "relationship": "CROSS_SELL"
 }
 ```
-If no relationship exits between given product ids, a 404 error will be issued
 
-### List a recommendation between two product ids
+
+### Read a recommendation between two product ids
 ```GET http://0.0.0.0:5000/recommendations/1/recommended-products/2```
 body
 ```
 {
+  "likes": 0,
   "product_id": 1,
   "recommendation_product_id": 2,
   "relationship": "CROSS_SELL"
@@ -137,11 +140,13 @@ GET http://0.0.0.0:5000/recommendations/1?type=UP_SELL
 ```
 [
     {
+        "likes": 0,
         "product_id": 1,
         "recommendation_product_id": 2,
         "relationship": "UP_SELL"
     },
     {
+        "likes": 0,
         "product_id": 1,
         "recommendation_product_id": 10,
         "relationship": "UP_SELL"
@@ -149,7 +154,21 @@ GET http://0.0.0.0:5000/recommendations/1?type=UP_SELL
 ]
 ```
 
-### Stateful Action - Clear all data entries
+### Stateful Action - Like a Recommendation
+When a recommendation is created, like count is default to 0  
+To like an existing recommendation, call   
+```PUT http://0.0.0.0:5000/recommendations/1/recommended-products/2/like```   
+```
+{
+    "likes": 1,
+    "product_id": 1,
+    "recommendation_product_id": 2,
+    "relationship": "UP_SELL"
+}
+```
+
+
+### Clear all data entries
 To reset the database, simply call   
 DELETE http://0.0.0.0:5000/recommendations
 

--- a/service/models.py
+++ b/service/models.py
@@ -42,12 +42,12 @@ class Recommendation(db.Model):
     relationship = db.Column(
         db.Enum(Type), nullable=False, server_default=(Type.GO_TOGETHER.name)
         )
-    likes = db.Column(db.Integer, server_default = 0)
+    likes = db.Column(db.Integer, default=0)
     ### -----------------------------------------------------------
     ### INSTANCE METHODS
     ### -----------------------------------------------------------
     def __repr__(self):
-        return "<Recommendation %r product_id=[%s] recommendation_product_id=[%s]>" % (self.relationship, self.product_id, self.recommendation_product_id)
+        return "<Recommendation %r product_id=[%s] recommendation_product_id=[%s] likes=[%s]>" % (self.relationship, self.product_id, self.recommendation_product_id, self.likes)
 
     def create(self):
         """
@@ -66,11 +66,7 @@ class Recommendation(db.Model):
             raise DataValidationError("Update called with empty relationship")
         logger.info("updating relationship between %s and %s", self.product_id, self.recommendation_product_id)
         db.session.commit()
-
-    def like(self):
-        logger.info("like the recommendation for product %s and product %s, like count is %s", self.product_id, self.recommendation_product_id, self.likes)
-        db.session.commit()
-
+        
     def delete(self):
         """
         Removes a recommendation type from the database

--- a/service/models.py
+++ b/service/models.py
@@ -42,6 +42,7 @@ class Recommendation(db.Model):
     relationship = db.Column(
         db.Enum(Type), nullable=False, server_default=(Type.GO_TOGETHER.name)
         )
+    likes = db.Column(db.Integer, server_default = 0)
     ### -----------------------------------------------------------
     ### INSTANCE METHODS
     ### -----------------------------------------------------------
@@ -66,6 +67,10 @@ class Recommendation(db.Model):
         logger.info("updating relationship between %s and %s", self.product_id, self.recommendation_product_id)
         db.session.commit()
 
+    def like(self):
+        logger.info("like the recommendation for product %s and product %s, like count is %s", self.product_id, self.recommendation_product_id, self.likes)
+        db.session.commit()
+
     def delete(self):
         """
         Removes a recommendation type from the database
@@ -76,7 +81,7 @@ class Recommendation(db.Model):
 
     def serialize(self):
         """ Serializes a Recommendation into a dictionary """
-        return {"product_id": self.product_id, "recommendation_product_id": self.recommendation_product_id, "relationship": self.relationship.name}
+        return {"product_id": self.product_id, "recommendation_product_id": self.recommendation_product_id, "relationship": self.relationship.name, "likes": self.likes}
 
     def deserialize(self, data):
         """

--- a/service/routes.py
+++ b/service/routes.py
@@ -134,6 +134,29 @@ def update_recommendations(product_id, recommendation_product_id):
         jsonify(message), status.HTTP_200_OK
     )
 
+
+##############################################################
+# LIKE A RECOMMENDATION
+######################################################################
+@app.route("/recommendations/<int:product_id>/recommended-products/<int:recommendation_product_id>/like", methods=["PUT"])
+def like_recommendations(product_id, recommendation_product_id):
+    """
+    like a relationship
+    """
+    app.logger.info("Request to like a recommendation between %s and %s", product_id, recommendation_product_id)
+    check_content_type("application/json")
+    
+    old_recommendation = Recommendation.find(product_id, recommendation_product_id)
+    if not old_recommendation:
+        raise NotFound("Recommendation for product id {} and {} was not found.".format(product_id, recommendation_product_id))
+    recommendation = old_recommendation
+    recommendation.likes += 1
+    recommendation.update()
+    message = recommendation.serialize()
+    return make_response(
+        jsonify(message), status.HTTP_200_OK
+    )
+
 ##############################################################
 # DELETE A RECOMMENDATION (RELATIONSHIP BETWEEN PRODUCTS)
 ######################################################################

--- a/service/routes.py
+++ b/service/routes.py
@@ -144,12 +144,10 @@ def like_recommendations(product_id, recommendation_product_id):
     like a relationship
     """
     app.logger.info("Request to like a recommendation between %s and %s", product_id, recommendation_product_id)
-    check_content_type("application/json")
-    
-    old_recommendation = Recommendation.find(product_id, recommendation_product_id)
-    if not old_recommendation:
+    recommendation = Recommendation.find(product_id, recommendation_product_id)
+    if not recommendation:
         raise NotFound("Recommendation for product id {} and {} was not found.".format(product_id, recommendation_product_id))
-    recommendation = old_recommendation
+    
     recommendation.likes += 1
     recommendation.update()
     message = recommendation.serialize()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -170,6 +170,19 @@ class TestRecommendationModel(unittest.TestCase):
             self.assertEqual(recommendation.product_id, query_id)
             self.assertEqual(recommendation.relationship, query_type)
 
+
+
+    def test_update_a_recommendation_likes(self):
+        """Like a recommendation"""
+        recommendation = RecommendationFactory()
+        
+        recommendation.create()
+        
+        self.assertEquals(recommendation.likes, 0)
+        recommendation.likes += 1
+        recommendation.update()
+        self.assertEqual(recommendation.likes, 1)
+        
     def test_clear_data(self):
         '''Clear all data entries'''
         recommendations = RecommendationFactory.create_batch(2)

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -241,3 +241,34 @@ class TestRecommendationServer(TestCase):
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
         result = resp.get_json()
         self.assertEqual(len(result), 0)
+
+    
+    def test_like_recommendation(self):
+        """Like an existing recommendation"""
+        # create a recommendation to like
+        test_recommendation = RecommendationFactory()
+        
+        resp = self.app.post(
+            "/recommendations", json=test_recommendation.serialize(), content_type="application/json"
+        )
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
+
+        # like the recommendation
+       
+        resp = self.app.put(
+            "/recommendations/{}/recommended-products/{}/like".format(test_recommendation.product_id,
+                                                                      test_recommendation.recommendation_product_id),
+        )
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        resp = self.app.get(
+            "/recommendations/{}/recommended-products/{}".format(test_recommendation.product_id, test_recommendation.recommendation_product_id), content_type="application/json"
+        )
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        data = resp.get_json()
+        self.assertEqual(data["likes"], 1)
+
+    def test_like_recommendation_not_found(self):
+        """ Like a Recommendation thats not found """
+        resp = self.app.put("/recommendations/0/recommended-products/0/like")
+        self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
+    


### PR DESCRIPTION
Implemented like endpoint.    Need``` vagrant destroy``` and  ```vagrant up``` to recreate schema. 

Updated README about how to call this action. 
```

(venv) vagrant@ubuntu:/vagrant$ nosetests

Test Cases for Recommendations Model 
- Clear all data entries
- Test create a recommendation
- Delete a recommendation from the database
- Test deserialization of a Recommendation
- Test deserialization of bad data
- Test deserialization of a Recommendation with missing data
- Find a recommendation type by product id and relationship id
- Find a recommendation type by two product ids
- Test list recommendations
- Test serialization of a Recommendation
- Update a recommendation type by two product ids
- Like a recommendation
- Update a recommendation type by two product ids without relationship

REST API Recommendation Server Tests 
- Delete all recommendations
- Create a new recommendation
- Create a Recommendation with missing data
- Create a Recommendation with no content type
- Delete a recommendation
- Get a single Recommendation
- Get a Recommendation thats not found
- Test index call
- Like an existing recommendation
- Like a Recommendation thats not found
- Get a list of recommendations
- Query recommendations for a specific id and type
- Update an existing recommendation
- create a Recommendation with no content type
- update a Recommendation that is not found

Name                  Stmts   Miss  Cover   Missing
---------------------------------------------------
service/__init__.py      25      4    84%   30, 39-42
service/models.py        69      0   100%
service/routes.py        87      0   100%
service/status.py        46      0   100%
---------------------------------------------------
TOTAL                   227      4    98%
-----------------------------------------------------------------------------
28 tests run in 3.214 seconds (28 tests passed)
```