### PR TITLE
Use environment variable TEST_DATABASE_URI

### DIFF
--- a/config.py
+++ b/config.py
@@ -6,7 +6,7 @@ import json
 # Get configuration from environment
 DATABASE_URI = os.getenv(
     "DATABASE_URI",
-    "postgres://vxbugyke:ht0RbVauOekmn1z-VsriWk94gmD9hMA_@chunee.db.elephantsql.com/vxbugyke"
+    "postgres://postgres:postgres@localhost:5432/postgres"
 )
 # override if we are running in Cloud Foundry
 if 'VCAP_SERVICES' in os.environ:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -9,8 +9,8 @@ import os
 from service.models import Recommendation, DataValidationError, db, Type
 from service import app
 from .factories import RecommendationFactory
-DATABASE_URI = os.getenv(
-    "DATABASE_URI", "postgres://postgres:postgres@localhost:5432/testdb"
+TEST_DATABASE_URI = os.getenv(
+    "TEST_DATABASE_URI", "postgres://postgres:postgres@localhost:5432/testdb"
 )
 ######################################################################
 #  RECOMMENDATIONS   M O D E L   T E S T   C A S E S
@@ -23,7 +23,7 @@ class TestRecommendationModel(unittest.TestCase):
         """This runs once before the entire test suite"""
         app.config["TESTING"] = True
         app.config["DEBUG"] = False
-        app.config["SQLALCHEMY_DATABASE_URI"] = DATABASE_URI
+        app.config["SQLALCHEMY_DATABASE_URI"] = TEST_DATABASE_URI
         app.logger.setLevel(logging.CRITICAL)
         Recommendation.init_db(app)
     @classmethod

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -17,8 +17,8 @@ import json
 
 BASE_URL = "/recommendations"
 CONTENT_TYPE_JSON = "application/json"
-DATABASE_URI = os.getenv(
-    "DATABASE_URI", "postgres://postgres:postgres@localhost:5432/testdb"
+TEST_DATABASE_URI = os.getenv(
+    "TEST_DATABASE_URI", "postgres://postgres:postgres@localhost:5432/testdb"
 )
 ######################################################################
 #  T E S T   C A S E S
@@ -32,7 +32,7 @@ class TestRecommendationServer(TestCase):
         app.config["TESTING"] = True
         app.config["DEBUG"] = False
         # Set up the test database
-        app.config["SQLALCHEMY_DATABASE_URI"] = DATABASE_URI
+        app.config["SQLALCHEMY_DATABASE_URI"] = TEST_DATABASE_URI
         app.logger.setLevel(logging.CRITICAL)
         Recommendation.init_db(app)
 


### PR DESCRIPTION
Use a different test data uri in unit tests. Set it to be different from DATABASE_URI.
Environment variable set in the cloud and test and build passed on the cloud. 